### PR TITLE
Adding new feed: Basket-Asyncapi

### DIFF
--- a/Basket-Asyncapi/feedinfo.json
+++ b/Basket-Asyncapi/feedinfo.json
@@ -3,10 +3,10 @@
   "name": "basket-asyncapi",
   "description": "The Basket writer proxies HTTP requests, forwarding them to the Basket topic in solace when a user adds a new item using the REST proxy. \n\n[Source Code within GitHub](https://github.com/confluentinc/examples/tree/7.4.0-post/microservices-orders)",
   "img": "assets/img/defaultfeed.png",
-  "contributor": "Tamimi",
-  "github": "TamimiGithub",
+  "contributor": "Giri",
+  "github": "gvensan",
   "domain": "E-commerce",
-  "tags": "ecommerce, shopping",
-  "lastUpdated": "2024-08-01T17:08:58.373Z",
+  "tags": "ecommerce, shopping, basket",
+  "lastUpdated": "2024-08-02T17:08:58.373Z",
   "contributed": true
 }


### PR DESCRIPTION
# Feed Title
Basket-Asyncapi

# Description
The Basket writer proxies HTTP requests, forwarding them to the Basket topic in solace when a user adds a new item using the REST proxy. 

[Source Code within GitHub](https://github.com/confluentinc/examples/tree/7.4.0-post/microservices-orders)

# Contributor
Giri

# GitHub
gvensan

# Domain
E-commerce

# Tags
ecommerce, shopping, basket

# Last Updated
2024-08-02T17:08:58.373Z

# Contributed
true